### PR TITLE
Fix: Reply message does not belong to request.

### DIFF
--- a/src/Core/Communication/Request.php
+++ b/src/Core/Communication/Request.php
@@ -74,6 +74,11 @@ class Request extends ActionMessage
         $response->setActionMessage($this);
         $mustDieAt = microtime(true) + config('app.request.wait_reply_message_ttl');
         $bus = Bus::instance();
+
+        if ($this->isServiceAuthorizationEnabled()) {
+            $this->authorizeService();
+        }
+
         $bus->startConsumeReplyMessages(static fn (Message $message) => $response->collectReplyMessage($message));
         $this->send();
 
@@ -90,10 +95,6 @@ class Request extends ActionMessage
 
     public function send(): void
     {
-        if ($this->isServiceAuthorizationEnabled()) {
-            $this->authorizeService();
-        }
-
         $this->publish();
     }
 


### PR DESCRIPTION
Сбор ответа на действие прерывается сбором ответов на авторизацию и не открывается снова. Поэтому сначала собираем ответы с auth, потом ответы на действие 